### PR TITLE
Bump dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,30 @@
 PATH
   remote: .
   specs:
-    mu-auth-sudo (0.1.0)
-      sparql-client (~> 3.0.1)
+    mu-auth-sudo (0.2.0)
+      sparql-client (~> 3.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.5)
-    connection_pool (2.2.2)
-    hamster (3.0.0)
-      concurrent-ruby (~> 1.0)
+    connection_pool (2.3.0)
     link_header (0.0.8)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     rake (13.0.1)
-    rdf (3.0.13)
-      hamster (~> 3.0)
+    rdf (3.2.9)
       link_header (~> 0.0, >= 0.0.8)
-    sparql-client (3.0.1)
-      net-http-persistent (>= 2.9, < 4)
-      rdf (~> 3.0)
+    sparql-client (3.1.2)
+      net-http-persistent (~> 4.0, >= 4.0.1)
+      rdf (~> 3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.1)
   mu-auth-sudo!
   rake (~> 13.0)
 
 BUNDLED WITH
-   1.16.1
+   2.1.4

--- a/lib/mu/version.rb
+++ b/lib/mu/version.rb
@@ -1,5 +1,5 @@
 module Mu
   module AuthSudo
-      VERSION = "0.1.1"
+      VERSION = "0.2.0"
   end
 end

--- a/mu-auth-sudo.gemspec
+++ b/mu-auth-sudo.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_dependency 'sparql-client', '~> 3.0.1'
+  spec.add_dependency 'sparql-client', '~> 3.1.0'
 end


### PR DESCRIPTION
Upgrade sparql-client to be compatible with version used in current mu-ruby-templates, from v2.11.0 and perhaps earlier