### PR TITLE
Relax sparql-client version constraint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     mu-auth-sudo (0.2.0)
-      sparql-client (~> 3.1.0)
+      sparql-client (~> 3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mu/auth-sudo.rb
+++ b/lib/mu/auth-sudo.rb
@@ -14,7 +14,7 @@ module Mu
       if ENV['MU_SPARQL_TIMEOUT']
         options[:read_timeout] = ENV['MU_SPARQL_TIMEOUT'].to_i
       end
-      SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'], options)
+      SPARQL::Client.new(ENV['MU_SPARQL_ENDPOINT'], **options)
     end
 
     def self.query(query)

--- a/mu-auth-sudo.gemspec
+++ b/mu-auth-sudo.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/mu-auth-sudo.gemspec
+++ b/mu-auth-sudo.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_dependency 'sparql-client', '~> 3.1.0'
+  spec.add_dependency "sparql-client", "~> 3.1"
 end


### PR DESCRIPTION
This is required for the new Ruby template.

The way we pass the `options` argument now is seemingly the required way since sparql-client v3.1.0 and Ruby v3